### PR TITLE
[#4] feat : 카테고리별 보도자료 조회 API 추가

### DIFF
--- a/src/main/java/com/youngs/controller/NewsController.java
+++ b/src/main/java/com/youngs/controller/NewsController.java
@@ -1,0 +1,40 @@
+package com.youngs.controller;
+
+import com.youngs.dto.NewsArticleDTO;
+import com.youngs.dto.ResponseDTO;
+import com.youngs.service.NewsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/news")
+public class NewsController {
+    private final NewsService newsService;
+
+    /**
+     * 카테고리에 해당하는 보도자료 조회 API
+     * @author 이지은
+     * @param categorySeq 보도자료 카테고리 인덱스. 1: 경제, 2: 증권, 3: 부동산
+     * */
+    @GetMapping("/{category_seq}")
+    public ResponseEntity<?> selectByCategorySeq(@PathVariable("category_seq") Long categorySeq){
+        try{
+            // 해당하는 카테고리에 칼럼이 있는 지 조회
+            List<NewsArticleDTO> newsArticleDTO = newsService.selectByCategorySeq(categorySeq);
+            return ResponseEntity.ok().body(newsArticleDTO);
+        } catch (Exception e){
+            ResponseDTO<Object> responseDTO = ResponseDTO.builder().message(e.getMessage()).build();
+            return ResponseEntity
+                    .internalServerError() // 500
+                    .body(responseDTO);
+        }
+    }
+
+}

--- a/src/main/java/com/youngs/dto/NewsArticleDTO.java
+++ b/src/main/java/com/youngs/dto/NewsArticleDTO.java
@@ -1,0 +1,14 @@
+package com.youngs.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewsArticleDTO {
+    private Long newsSeq; //세부 보도자료 인덱스
+    private String title; //보도자료 제목
+    private String url; //보도자료 URL
+}

--- a/src/main/java/com/youngs/entity/NewsArticle.java
+++ b/src/main/java/com/youngs/entity/NewsArticle.java
@@ -2,15 +2,18 @@ package com.youngs.entity;
 
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Date;
 
-@Getter
-@Setter
+@Data
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name ="news_article")
+@EntityListeners(AuditingEntityListener.class)
 public class NewsArticle {
     @Id
     @Column(name = "news_seq")
@@ -24,9 +27,15 @@ public class NewsArticle {
     private String url; //세부 보도자료 URL
 
     @Column(nullable = false)
+    private String description; //보도자료 요약
+
+    @Column(name="pub_date",nullable = false)
+    private Date pubDate;
+
+    @Column(nullable = false)
     private Long categorySeq; //보도자료 카테고리 인덱스
 
     @CreatedDate
-    @Column(name="created_at", nullable = false)
+    @Column(name="created_at")
     private LocalDateTime createdAt; //생성일
 }

--- a/src/main/java/com/youngs/entity/NewsArticle.java
+++ b/src/main/java/com/youngs/entity/NewsArticle.java
@@ -1,0 +1,32 @@
+package com.youngs.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewsArticle {
+    @Id
+    @Column(name = "news_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long newsSeq; //세부 보도자료 인덱스
+
+    @Column(nullable = false)
+    private String title; //세부 보도자료 재목
+
+    @Column(nullable = false)
+    private String url; //세부 보도자료 URL
+
+    @Column(nullable = false)
+    private Long categorySeq; //보도자료 카테고리 인덱스
+
+    @CreatedDate
+    @Column(name="created_at", nullable = false)
+    private LocalDateTime createdAt; //생성일
+}

--- a/src/main/java/com/youngs/entity/NewsCategory.java
+++ b/src/main/java/com/youngs/entity/NewsCategory.java
@@ -1,0 +1,26 @@
+package com.youngs.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewsCategory {
+    @Id
+    @Column(name = "category_seq")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long categorySeq; //보도자료 카테고리 인덱스
+
+    @Column(name="category_name", nullable = false)
+    private String categoryName; //보도자료 카테고리 명
+
+    @CreatedDate
+    @Column(name="created_at", nullable = false)
+    private LocalDateTime createdAt; //생성일
+}

--- a/src/main/java/com/youngs/entity/NewsCategory.java
+++ b/src/main/java/com/youngs/entity/NewsCategory.java
@@ -2,15 +2,18 @@ package com.youngs.entity;
 
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Getter
-@Setter
+@Data
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name ="news_category")
+@EntityListeners(AuditingEntityListener.class)
 public class NewsCategory {
     @Id
     @Column(name = "category_seq")
@@ -21,6 +24,6 @@ public class NewsCategory {
     private String categoryName; //보도자료 카테고리 명
 
     @CreatedDate
-    @Column(name="created_at", nullable = false)
+    @Column(name="created_at")
     private LocalDateTime createdAt; //생성일
 }

--- a/src/main/java/com/youngs/repository/NewsRepository.java
+++ b/src/main/java/com/youngs/repository/NewsRepository.java
@@ -1,0 +1,18 @@
+package com.youngs.repository;
+
+import com.youngs.entity.NewsArticle;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface NewsRepository extends JpaRepository<NewsArticle, Integer> {
+
+    /**
+     * 카테고리에 해당하는 보도자료 리스트 가져오기
+     * @author 이지은
+     * @param categorySeq 보도자료 카테고리 인덱스. 1: 경제, 2: 증권, 3: 부동산
+     * */
+    @Query(value = "select n from NewsArticle n where n.categorySeq=?1")
+    List<NewsArticle> selectByCategorySeq(Long categorySeq);
+}

--- a/src/main/java/com/youngs/service/NewsService.java
+++ b/src/main/java/com/youngs/service/NewsService.java
@@ -1,0 +1,14 @@
+package com.youngs.service;
+
+import com.youngs.dto.NewsArticleDTO;
+import java.util.List;
+
+public interface NewsService {
+
+    /**
+     * 카테고리에 해당하는 보도자료 조회
+     * @author 이지은
+     * @param categorySeq 보도자료 카테고리 인덱스. 1: 경제, 2: 증권, 3: 부동산
+     * */
+    List<NewsArticleDTO> selectByCategorySeq(Long categorySeq);
+}

--- a/src/main/java/com/youngs/service/NewsServiceImpl.java
+++ b/src/main/java/com/youngs/service/NewsServiceImpl.java
@@ -1,0 +1,39 @@
+package com.youngs.service;
+
+import com.youngs.dto.NewsArticleDTO;
+import com.youngs.entity.NewsArticle;
+import com.youngs.repository.NewsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NewsServiceImpl implements NewsService {
+    private final NewsRepository newsRep;
+
+    /**
+     * 카테고리에 해당하는 보도자료 조회
+     * @author 이지은
+     * @param categorySeq 보도자료 카테고리 인덱스. 1: 경제, 2: 증권, 3: 부동산
+     * @exception RuntimeException 가져온 보도자료가 없다면 throw
+     * @return 카테고리에 해당하는 보도자료 리스트
+     * */
+    @Override
+    public List<NewsArticleDTO> selectByCategorySeq(Long categorySeq) throws RuntimeException {
+        List<NewsArticle> newsList = newsRep.selectByCategorySeq(categorySeq);
+        if(newsList.isEmpty()){ //가져온 보도자료가 없다면
+            throw new RuntimeException("조회할 보도자료가 없습니다");
+        }
+
+        List<NewsArticleDTO> newsDTOList = new ArrayList<>();
+        for(NewsArticle news : newsList){
+            newsDTOList.add(new NewsArticleDTO(news.getNewsSeq(), news.getTitle(), news.getUrl()));
+        }
+        return newsDTOList;
+    }
+}


### PR DESCRIPTION
### 카테고리에 해당하는 보도자료가 존재할 때

<img width="787" alt="스크린샷 2023-10-12 오전 10 34 23" src="https://github.com/shinhanProject/youngs-back/assets/44528897/b4b7e93b-1a66-41c3-b81c-3004a1d57119">

<br>

### 카테고리에 해당하는 보도자료가 존재하지 않을 때

<img width="669" alt="스크린샷 2023-10-12 오전 10 34 09" src="https://github.com/shinhanProject/youngs-back/assets/44528897/e1f0ea57-7a1d-44ee-9bb4-65e1cdc6621b">
