### PR TITLE
[#31] fix: 유저 요약 정보 최신 순 정렬

### DIFF
--- a/src/main/java/com/youngs/repository/NewsSummaryRepository.java
+++ b/src/main/java/com/youngs/repository/NewsSummaryRepository.java
@@ -25,7 +25,8 @@ public interface NewsSummaryRepository extends JpaRepository<NewsSummary, Long> 
             "from basic_summary s\n" +
             "join basic_article a on s.basic_seq = a.basic_seq\n" +
             "join basic_category c on a.category_seq = c.category_seq\n" +
-            "where s.user_seq=?1", nativeQuery = true)
+            "where s.user_seq=?1\n" +
+            "order by modifiedAt desc", nativeQuery = true)
     List<SummaryListDTO> findSummaryList(Long userSeq);
 
 }


### PR DESCRIPTION
### 로그인한 자신의 요약 정보 조회 시 - status:200
<img width="751" alt="스크린샷 2023-10-16 오후 5 05 31" src="https://github.com/shinhanProject/youngs-back/assets/44528897/5dd8a739-5269-463d-ab7c-6c15d4d9e5f9">

<br><br>

### 다른 사용자의 비공개 설정이 되어 있는 정보 조회 시 - status:204
<img width="709" alt="스크린샷 2023-10-16 오후 5 05 14" src="https://github.com/shinhanProject/youngs-back/assets/44528897/74e29d2c-c4bc-479d-b445-ce3098525b90">

<br><br>

### 다른 사용자의 공개 설정이 되어 있는 정보 조회 시 - status:200
<img width="758" alt="스크린샷 2023-10-16 오후 5 04 59" src="https://github.com/shinhanProject/youngs-back/assets/44528897/5c5667ad-2226-44b7-a68a-5672be24ac50">

<br><br>

### 다른 사용자의 요약 정보가 비어있을 시 - status:204
<img width="742" alt="스크린샷 2023-10-16 오후 5 09 37" src="https://github.com/shinhanProject/youngs-back/assets/44528897/5f8e5456-41df-4138-85ff-755fc206cccd">


<br><br>

### 존재하지 않는 사용자 정보 조회 시 - status:500
<img width="742" alt="스크린샷 2023-10-16 오후 5 05 47" src="https://github.com/shinhanProject/youngs-back/assets/44528897/847b58fa-3afa-4288-86f8-1ba6ddf2072e">
