### PR TITLE
[#45] fix : 요약 작성 시 이미 작성되어 있는 요약 체크 수정

### DIFF
--- a/src/main/java/com/youngs/controller/SummaryController.java
+++ b/src/main/java/com/youngs/controller/SummaryController.java
@@ -30,10 +30,12 @@ public class SummaryController {
      **/
     @PostMapping()
     public ResponseEntity<?> writeSummary(@AuthenticationPrincipal PrincipalUserDetails currentUserDetails, @RequestBody SummaryDTO summaryDTO) {
-        if (summaryDTO.getCategory().equals("basic")) { // 기초 지식 요약 작성
+        String category = summaryDTO.getCategory(); // 요약을 작성할 카테고리
+
+        if (category.equals("basic")) { // 기초 지식 요약 작성
             return summaryService.writeBasicSummary(currentUserDetails.getUserSeq(), summaryDTO);
         }
-        else if (summaryDTO.getCategory().equals("news")) { // 보도자료 요약 작성
+        else if (category.equals("news")) { // 보도자료 요약 작성
             return summaryService.writeNewsSummary(currentUserDetails.getUserSeq(), summaryDTO);
         }
 

--- a/src/main/java/com/youngs/repository/BasicSummaryRepository.java
+++ b/src/main/java/com/youngs/repository/BasicSummaryRepository.java
@@ -4,5 +4,12 @@ import com.youngs.entity.BasicSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BasicSummaryRepository extends JpaRepository<BasicSummary, Long> {
+    /**
+     * 사용자 고유 번호와 기초 지식 글 고유 번호로 기초 지식 요약 조회
+     * @author : 박상희
+     * @param userSeq : 사용자 고유 번호
+     * @param basicSeq : 기초 지식 글 고유 번호
+     * @return 기초 지식 요약
+     **/
     BasicSummary findByUserUserSeqAndBasicArticleBasicSeq(Long userSeq, Long basicSeq);
 }

--- a/src/main/java/com/youngs/repository/BasicSummaryRepository.java
+++ b/src/main/java/com/youngs/repository/BasicSummaryRepository.java
@@ -4,4 +4,5 @@ import com.youngs.entity.BasicSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BasicSummaryRepository extends JpaRepository<BasicSummary, Long> {
+    BasicSummary findByUserUserSeqAndBasicArticleBasicSeq(Long userSeq, Long basicSeq);
 }

--- a/src/main/java/com/youngs/repository/NewsSummaryRepository.java
+++ b/src/main/java/com/youngs/repository/NewsSummaryRepository.java
@@ -4,4 +4,5 @@ import com.youngs.entity.NewsSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NewsSummaryRepository extends JpaRepository<NewsSummary, Long> {
+    NewsSummary findByUserUserSeqAndNewsArticleNewsSeq(Long userSeq, Long newsSeq);
 }

--- a/src/main/java/com/youngs/repository/NewsSummaryRepository.java
+++ b/src/main/java/com/youngs/repository/NewsSummaryRepository.java
@@ -8,6 +8,13 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 public interface NewsSummaryRepository extends JpaRepository<NewsSummary, Long> {
+    /**
+     * 사용자 고유 번호와 보도자료 글 고유 번호로 보도자료 요약 조회
+     * @author : 박상희
+     * @param userSeq : 사용자 고유 번호
+     * @param newsSeq : 보도자료 글 고유 번호
+     * @return 보도자료 요약
+     **/
     NewsSummary findByUserUserSeqAndNewsArticleNewsSeq(Long userSeq, Long newsSeq);
 
     /**

--- a/src/main/java/com/youngs/service/SummaryServiceImpl.java
+++ b/src/main/java/com/youngs/service/SummaryServiceImpl.java
@@ -36,8 +36,9 @@ public class SummaryServiceImpl implements SummaryService {
     @Override
     public ResponseEntity<?> writeBasicSummary(Long userSeq, SummaryDTO summaryDTO) {
         try {
-            Long basicSeq = summaryDTO.getArticleId();
-            if (basicSummaryRepository.existsById(basicSeq)) { // 이미 요약 작성이 되어 있을 경우
+            Long basicSeq = summaryDTO.getArticleId(); // 요약을 작성할 기초 지식 글의 고유 번호
+
+            if (basicSummaryRepository.findByUserUserSeqAndBasicArticleBasicSeq(userSeq, basicSeq) != null) { // 이미 요약 작성이 되어 있을 경우
                 throw new RuntimeException("이미 기초 지식 요약이 작성되어 있습니다.");
             }
 
@@ -74,7 +75,8 @@ public class SummaryServiceImpl implements SummaryService {
     public ResponseEntity<?> writeNewsSummary(Long userSeq, SummaryDTO summaryDTO) {
         try {
             Long newsSeq = summaryDTO.getArticleId(); // 요약을 작성할 보도자료 고유 번호
-            if (newsSummaryRepository.existsById(newsSeq)) { // 이미 요약 작성이 되어 있을 경우
+
+            if (newsSummaryRepository.findByUserUserSeqAndNewsArticleNewsSeq(userSeq, newsSeq) != null) { // 이미 요약 작성이 되어 있을 경우
                 throw new RuntimeException("이미 보도자료 요약이 작성되어 있습니다.");
             }
 


### PR DESCRIPTION
> 이미 작성되어 있는 요약 체크 방법 수정

<br/>
<br/>

- 기초 지식 요약 작성
  - 로그인한 사용자
    - 이미 기초 지식 요약이 작성되어 있을 경우
      <img width="646" alt="image" src="https://github.com/shinhanProject/youngs-back/assets/66476874/7197f6d9-ee0c-4944-80b2-cc5ea848342e">

      <br/>

    - 작성된 기초 지식 요약이 없을 경우
      <img width="644" alt="image" src="https://github.com/shinhanProject/youngs-back/assets/66476874/f71d1029-ae9c-4248-9d49-9a3a2821fd6c">

    <br/>

  - 로그인하지 않은 사용자
    <img width="643" alt="image" src="https://github.com/shinhanProject/youngs-back/assets/66476874/9c917da6-71a9-49c1-aee3-8e6b6852836f">

<br/>
<br/>

- 보도자료 요약 작성
  - 로그인한 사용자
    - 이미 보도자료 요약이 작성되어 있을 경우
      <img width="642" alt="image" src="https://github.com/shinhanProject/youngs-back/assets/66476874/a9d9c3f7-da46-4cc9-b597-fd1e2425ff74">

      <br/>

    - 작성된 보도자료 요약이 없을 경우
      <img width="644" alt="image" src="https://github.com/shinhanProject/youngs-back/assets/66476874/026d84a2-cb41-4ddc-9d72-4e4bb9a84f6f">

    <br/>

  - 로그인하지 않은 사용자
    <img width="644" alt="image" src="https://github.com/shinhanProject/youngs-back/assets/66476874/e561b3d5-6d3f-4bc2-96ac-9ca141ae878b">
