### PR TITLE
[#16] feat : 요약 정보 공개 옵션 변경 API

### DIFF
--- a/src/main/java/com/youngs/controller/MyPageController.java
+++ b/src/main/java/com/youngs/controller/MyPageController.java
@@ -133,4 +133,17 @@ public class MyPageController {
         return myPageService.searchSummary(currentUserDetails, userSeq);
     }
 
+
+    /**
+     * 요약 정보 공개 옵션 변경  API
+     * @author 이지은
+     * @param currentUserDetails : 현재 로그인한 사용자 정보
+     * @param userSeq : 조회할 사용자 고유 번호
+     * @return 사용자 요약 정보 리스트
+     * */
+    @PatchMapping("/{userSeq}/private")
+    public ResponseEntity<?> changeIsPrivate(@AuthenticationPrincipal PrincipalUserDetails currentUserDetails, @PathVariable Long userSeq, @RequestBody Map<String, Integer> request){
+        int isPrivate = request.get("isPrivate");
+        return myPageService.changeIsPrivate(currentUserDetails, userSeq, isPrivate);
+    }
 }

--- a/src/main/java/com/youngs/service/MyPageService.java
+++ b/src/main/java/com/youngs/service/MyPageService.java
@@ -68,5 +68,14 @@ public interface MyPageService {
      * */
     ResponseEntity<?> searchSummary(PrincipalUserDetails currentUserDetails, Long userSeq);
 
+    /**
+     * 요약 정보 공개 옵션 변경  API
+     *
+     * @param currentUserDetails : 현재 로그인한 사용자 정보
+     * @param userSeq            : 공개여부 변경할 사용자의 고유 번호
+     * @param isPrivate          : 공개여부 - 0: 공개 1: 비공개
+     * @author 이지은
+     * */
+    ResponseEntity<?> changeIsPrivate(PrincipalUserDetails currentUserDetails, Long userSeq, int isPrivate);
 
 }


### PR DESCRIPTION

### 옳은 요청을 보냈을 때 
* 요청을 보내기 전 
<img width="934" alt="스크린샷 2023-10-17 오후 7 14 12" src="https://github.com/shinhanProject/youngs-back/assets/44528897/2dd877c5-03ac-472d-bde8-dd29154a7f41">

<br><br>

* isPrivate = 1 요청
<img width="689" alt="스크린샷 2023-10-17 오후 7 14 58" src="https://github.com/shinhanProject/youngs-back/assets/44528897/69f1a91d-ee95-444f-8ede-f0974f1625cc">

<br>

* 요청을 보낸 후 
<img width="925" alt="스크린샷 2023-10-17 오후 7 15 24" src="https://github.com/shinhanProject/youngs-back/assets/44528897/4a450c16-3a4a-475e-8c9f-f5592ba7dd5c">


<br><br>

### 다른 사람의 공개 옵션 변경힐 때
<img width="694" alt="스크린샷 2023-10-17 오후 7 12 43" src="https://github.com/shinhanProject/youngs-back/assets/44528897/dc326b67-c934-4a93-a2b9-3046e0e3416d">

<br>

### 잘못된 요청을 보낼 때
<img width="675" alt="스크린샷 2023-10-17 오후 7 13 08" src="https://github.com/shinhanProject/youngs-back/assets/44528897/ebf656f3-6cab-4679-8978-7c32640fcde6">
